### PR TITLE
Update openapi.yaml, volume label required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15170,6 +15170,7 @@ paths:
                   minLength: 1
                   maxLength: 32
                   pattern: '^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$'
+                  required: true
                 config_id:
                   type: integer
                   description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15141,6 +15141,8 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - label
               properties:
                 region:
                   type: string
@@ -15170,7 +15172,6 @@ paths:
                   minLength: 1
                   maxLength: 32
                   pattern: '^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$'
-                  required: true
                 config_id:
                   type: integer
                   description: >


### PR DESCRIPTION
The volume label is required according to the behavior of the API and the intent matches this behavior because the source code agrees with the label being a required field upon volume creation.